### PR TITLE
feat: let user peek the next cleaning day

### DIFF
--- a/core/configs/consts.py
+++ b/core/configs/consts.py
@@ -16,6 +16,6 @@ base_dates_campus_cleaning = {
     3: [date(2019, 4, 17), date(2019, 4, 26), None, date(2019, 5, 6)],
     4: [None, date(2019, 4, 22), date(2019, 5, 1), date(2019, 5, 10)],
 }  # campus_number -> some day with cleaning
-interval = 28
+cleaning_interval = 28
 default_timezone = pytz.timezone("Europe/Moscow")
 job_id_format = "cleaning_reminder:{chat_id}:{campus_number}:{index}"

--- a/core/configs/consts.py
+++ b/core/configs/consts.py
@@ -16,6 +16,6 @@ base_dates_campus_cleaning = {
     3: [date(2019, 4, 17), date(2019, 4, 26), None, date(2019, 5, 6)],
     4: [None, date(2019, 4, 22), date(2019, 5, 1), date(2019, 5, 10)],
 }  # campus_number -> some day with cleaning
-interval_btw_cleaning = timedelta(days=10)
+interval = 28
 default_timezone = pytz.timezone("Europe/Moscow")
 job_id_format = "cleaning_reminder:{chat_id}:{campus_number}:{index}"

--- a/core/handlers.py
+++ b/core/handlers.py
@@ -110,12 +110,13 @@ async def help_command_handler(msg: types.Message):
 @dp.message_handler(commands=["schedule"], state="*")
 async def schedule_command_handler(msg: types.Message):
     from core.strings.scripts import i18n
-    scheduled_cleanings = []
+
+    next_cleaning_dates = []
     now = datetime.datetime.now(consts.default_timezone).replace(tzinfo=None)
-    interval = 28
     text = [_("schedule_command_text"),]
+
     for base_dates in consts.base_dates_campus_cleaning.values():
-        days_left = interval
+        days_left = consts.interval
         for i in range(4):
             base_date = base_dates[i]
             if base_date:
@@ -124,10 +125,13 @@ async def schedule_command_handler(msg: types.Message):
                     month=base_date.month,
                     day=base_date.day,
                 )
-                days_left = min(interval - (now - base_date).days % interval, days_left)
-        scheduled_cleanings.append(((now + datetime.timedelta(days=days_left)).strftime("%d.%m.%Y (%A)"), days_left))
-    text.extend([_("scheduled_cleaning").format(campus_number=index+1, date=item[0],
-                    days_left=item[1]) for (index, item) in enumerate(scheduled_cleanings)])
+                days_left = min(consts.interval - (now - base_date).days % consts.interval, days_left)
+
+        next_cleaning = now + datetime.timedelta(days=days_left)
+        next_cleaning_dates.append(((next_cleaning).strftime("%d.%m.%Y (%A)"), days_left))
+        
+    text.extend([_("scheduled_cleaning").format(campus_number=index+1, date=date,
+                    days_left=days_left) for (index, (date, days_left)) in enumerate(next_cleaning_dates)])
     await bot.send_message(msg.chat.id, '\n'.join(map(str, text)))
 
 

--- a/core/handlers.py
+++ b/core/handlers.py
@@ -106,6 +106,17 @@ async def help_command_handler(msg: types.Message):
         msg.chat.id, _("help_cmd_text, formats: {name}").format(name=user.first_name)
     )
 
+@dp.message_handler(commands=["peek"], state="*")
+async def peek_command_handler(msg: types.Message):
+    for job in scheduler.get_jobs():
+        extra = 1 if job.id.endswith("day_before") else 0
+        job_chat_id = job.args[0]
+        if job_chat_id == msg.from_user.id:
+            text = f'{_("remainder_is_scheduled")} {(job.next_run_time + datetime.timedelta(days=extra)).strftime("%d.%m.%Y (%A)")}'
+            break
+    else:
+        text = _("remainder_is_not_scheduled")
+    await bot.send_message(msg.chat.id, text)
 
 @dp.message_handler(commands="language", state="*")
 async def language_cmd_handler(msg: types.Message):

--- a/core/handlers.py
+++ b/core/handlers.py
@@ -107,20 +107,6 @@ async def help_command_handler(msg: types.Message):
     )
 
 
-@dp.message_handler(commands=["peek"], state="*")
-async def peek_command_handler(msg: types.Message):
-    for job in scheduler.get_jobs():
-        extra = 1 if job.id.endswith("day_before") else 0
-        job_chat_id = job.args[0]
-        if job_chat_id == msg.from_user.id:
-            remainder_is_scheduled_text = _("remainder_is_scheduled")
-            text = f'{remainder_is_scheduled_text} {(job.next_run_time + datetime.timedelta(days=extra)).strftime("%d.%m.%Y (%A)")}'
-            break
-    else:
-        text = _("remainder_is_not_scheduled")
-    await bot.send_message(msg.chat.id, text)
-
-
 @dp.message_handler(commands=["schedule"], state="*")
 async def schedule_command_handler(msg: types.Message):
     from core.strings.scripts import i18n

--- a/core/handlers.py
+++ b/core/handlers.py
@@ -113,7 +113,9 @@ async def schedule_command_handler(msg: types.Message):
 
     next_cleaning_dates = []
     now = datetime.datetime.now(consts.default_timezone).replace(tzinfo=None)
-    text = [_("schedule_command_text"),]
+    text = [
+        _("schedule_command_text"),
+    ]
 
     for base_dates in consts.base_dates_campus_cleaning.values():
         days_left = consts.interval
@@ -121,18 +123,27 @@ async def schedule_command_handler(msg: types.Message):
             base_date = base_dates[i]
             if base_date:
                 base_date = datetime.datetime(
-                    year=base_date.year,
-                    month=base_date.month,
-                    day=base_date.day,
+                    year=base_date.year, month=base_date.month, day=base_date.day,
                 )
-                days_left = min(consts.interval - (now - base_date).days % consts.interval, days_left)
+                days_left = min(
+                    consts.interval - (now - base_date).days % consts.interval,
+                    days_left,
+                )
 
         next_cleaning = now + datetime.timedelta(days=days_left)
-        next_cleaning_dates.append(((next_cleaning).strftime("%d.%m.%Y (%A)"), days_left))
-        
-    text.extend([_("scheduled_cleaning").format(campus_number=index+1, date=date,
-                    days_left=days_left) for (index, (date, days_left)) in enumerate(next_cleaning_dates)])
-    await bot.send_message(msg.chat.id, '\n'.join(map(str, text)))
+        next_cleaning_dates.append(
+            ((next_cleaning).strftime("%d.%m.%Y (%A)"), days_left)
+        )
+
+    text.extend(
+        [
+            _("scheduled_cleaning").format(
+                campus_number=index + 1, date=date, days_left=days_left
+            )
+            for (index, (date, days_left)) in enumerate(next_cleaning_dates)
+        ]
+    )
+    await bot.send_message(msg.chat.id, "\n".join(map(str, text)))
 
 
 @dp.message_handler(commands="language", state="*")

--- a/core/handlers.py
+++ b/core/handlers.py
@@ -118,22 +118,20 @@ async def schedule_command_handler(msg: types.Message):
     ]
 
     for base_dates in consts.base_dates_campus_cleaning.values():
-        days_left = consts.interval
-        for i in range(4):
-            base_date = base_dates[i]
+        days_left = consts.cleaning_interval
+        for base_date in base_dates:
             if base_date:
                 base_date = datetime.datetime(
                     year=base_date.year, month=base_date.month, day=base_date.day,
                 )
                 days_left = min(
-                    consts.interval - (now - base_date).days % consts.interval,
+                    consts.cleaning_interval
+                    - (now - base_date).days % consts.cleaning_interval,
                     days_left,
                 )
 
         next_cleaning = now + datetime.timedelta(days=days_left)
-        next_cleaning_dates.append(
-            ((next_cleaning).strftime("%d.%m.%Y (%A)"), days_left)
-        )
+        next_cleaning_dates.append((next_cleaning.strftime("%d.%m.%Y (%A)"), days_left))
 
     text.extend(
         [

--- a/locales/en/LC_MESSAGES/bot.po
+++ b/locales/en/LC_MESSAGES/bot.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2020-02-05 21:36+0300\n"
+"POT-Creation-Date: 2020-02-06 11:57+0300\n"
 "PO-Revision-Date: 2019-07-22 21:06+0300\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language: en\n"
@@ -45,59 +45,59 @@ msgstr ""
 msgid "schedule_command_text"
 msgstr "The scheduled cleanings for each dorm respectfully:"
 
-#: core/handlers.py:129
+#: core/handlers.py:133
 msgid "scheduled_cleaning"
 msgstr "#{campus_number}: {date}. In {days_left} days"
 
-#: core/handlers.py:138
+#: core/handlers.py:142
 msgid "choose language"
 msgstr "Choose language"
 
-#: core/handlers.py:156
+#: core/handlers.py:160
 msgid "language is set"
 msgstr "Language is set"
 
-#: core/handlers.py:163
+#: core/handlers.py:167
 msgid "set_is_day_before"
 msgstr "When to remind you?"
 
-#: core/handlers.py:183 core/handlers.py:411
+#: core/handlers.py:187 core/handlers.py:415
 msgid "choose_campus"
 msgstr "Choose campus"
 
-#: core/handlers.py:210
+#: core/handlers.py:214
 msgid "choose_cleaning_reminder_time"
 msgstr "Choose time of reminder"
 
-#: core/handlers.py:224
+#: core/handlers.py:228
 msgid "personal_reminder_cleaning_day_before"
 msgstr "Tomorrow is the day of cleaning in campus <b>{number}</b>"
 
-#: core/handlers.py:229
+#: core/handlers.py:233
 msgid "personal_reminder_cleaning, formats: number"
 msgstr "Today is the day of cleaning in campus <b>{number}</b>"
 
-#: core/handlers.py:296
+#: core/handlers.py:300
 msgid "cleaning_reminder_set"
 msgstr "Reminder is set"
 
-#: core/handlers.py:356
+#: core/handlers.py:360
 msgid "no_reminders_set"
 msgstr "You have no reminders"
 
-#: core/handlers.py:361
+#: core/handlers.py:365
 msgid "remove_set_is_day_before"
 msgstr "Remove reminder from which day?"
 
-#: core/handlers.py:435
+#: core/handlers.py:439
 msgid "reminder_is_off"
 msgstr "Reminder is turned off"
 
-#: core/handlers.py:445
+#: core/handlers.py:449
 msgid "mailing_everyone"
 msgstr "Next message will be sent to every user"
 
-#: core/handlers.py:451
+#: core/handlers.py:455
 msgid "sent_to_everyone"
 msgstr "Message is sent to everyone"
 

--- a/locales/en/LC_MESSAGES/bot.po
+++ b/locales/en/LC_MESSAGES/bot.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2020-02-05 14:42+0300\n"
+"POT-Creation-Date: 2020-02-05 21:36+0300\n"
 "PO-Revision-Date: 2019-07-22 21:06+0300\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language: en\n"
@@ -42,70 +42,62 @@ msgstr ""
 "/peek - peek the next cleaning day\n"
 
 #: core/handlers.py:116
-msgid "remainder_is_scheduled"
-msgstr "The next cleaning is due to"
-
-#: core/handlers.py:120
-msgid "remainder_is_not_scheduled"
-msgstr "No cleanings scheduled. Send /on to turn on the remainder"
-
-#: core/handlers.py:130
 msgid "schedule_command_text"
 msgstr "The scheduled cleanings for each dorm respectfully:"
 
-#: core/handlers.py:143
+#: core/handlers.py:129
 msgid "scheduled_cleaning"
 msgstr "#{campus_number}: {date}. In {days_left} days"
 
-#: core/handlers.py:152
+#: core/handlers.py:138
 msgid "choose language"
 msgstr "Choose language"
 
-#: core/handlers.py:170
+#: core/handlers.py:156
 msgid "language is set"
 msgstr "Language is set"
 
-#: core/handlers.py:177
+#: core/handlers.py:163
 msgid "set_is_day_before"
 msgstr "When to remind you?"
 
-#: core/handlers.py:197 core/handlers.py:425
+#: core/handlers.py:183 core/handlers.py:411
 msgid "choose_campus"
 msgstr "Choose campus"
 
-#: core/handlers.py:224
+#: core/handlers.py:210
 msgid "choose_cleaning_reminder_time"
 msgstr "Choose time of reminder"
 
-#: core/handlers.py:238
+#: core/handlers.py:224
 msgid "personal_reminder_cleaning_day_before"
 msgstr "Tomorrow is the day of cleaning in campus <b>{number}</b>"
 
-#: core/handlers.py:243
+#: core/handlers.py:229
 msgid "personal_reminder_cleaning, formats: number"
 msgstr "Today is the day of cleaning in campus <b>{number}</b>"
 
-#: core/handlers.py:310
+#: core/handlers.py:296
 msgid "cleaning_reminder_set"
 msgstr "Reminder is set"
 
-#: core/handlers.py:370
+#: core/handlers.py:356
 msgid "no_reminders_set"
 msgstr "You have no reminders"
 
-#: core/handlers.py:375
+#: core/handlers.py:361
 msgid "remove_set_is_day_before"
 msgstr "Remove reminder from which day?"
 
-#: core/handlers.py:449
+#: core/handlers.py:435
 msgid "reminder_is_off"
 msgstr "Reminder is turned off"
 
-#: core/handlers.py:459
+#: core/handlers.py:445
 msgid "mailing_everyone"
 msgstr "Next message will be sent to every user"
 
-#: core/handlers.py:465
+#: core/handlers.py:451
 msgid "sent_to_everyone"
 msgstr "Message is sent to everyone"
 

--- a/locales/en/LC_MESSAGES/bot.po
+++ b/locales/en/LC_MESSAGES/bot.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2020-02-06 11:57+0300\n"
+"POT-Creation-Date: 2020-02-06 18:41+0300\n"
 "PO-Revision-Date: 2019-07-22 21:06+0300\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language: en\n"
@@ -39,65 +39,65 @@ msgstr ""
 "/off - turn off reminder\n"
 "/start - start message\n"
 "/help - help message\n"
-"/peek - peek the next cleaning day\n"
+"/schedule - find out scheduled cleanings for each dorm\n"
 
-#: core/handlers.py:116
+#: core/handlers.py:117
 msgid "schedule_command_text"
 msgstr "The scheduled cleanings for each dorm respectfully:"
 
-#: core/handlers.py:133
+#: core/handlers.py:138
 msgid "scheduled_cleaning"
 msgstr "#{campus_number}: {date}. In {days_left} days"
 
-#: core/handlers.py:142
+#: core/handlers.py:151
 msgid "choose language"
 msgstr "Choose language"
 
-#: core/handlers.py:160
+#: core/handlers.py:169
 msgid "language is set"
 msgstr "Language is set"
 
-#: core/handlers.py:167
+#: core/handlers.py:176
 msgid "set_is_day_before"
 msgstr "When to remind you?"
 
-#: core/handlers.py:187 core/handlers.py:415
+#: core/handlers.py:196 core/handlers.py:424
 msgid "choose_campus"
 msgstr "Choose campus"
 
-#: core/handlers.py:214
+#: core/handlers.py:223
 msgid "choose_cleaning_reminder_time"
 msgstr "Choose time of reminder"
 
-#: core/handlers.py:228
+#: core/handlers.py:237
 msgid "personal_reminder_cleaning_day_before"
 msgstr "Tomorrow is the day of cleaning in campus <b>{number}</b>"
 
-#: core/handlers.py:233
+#: core/handlers.py:242
 msgid "personal_reminder_cleaning, formats: number"
 msgstr "Today is the day of cleaning in campus <b>{number}</b>"
 
-#: core/handlers.py:300
+#: core/handlers.py:309
 msgid "cleaning_reminder_set"
 msgstr "Reminder is set"
 
-#: core/handlers.py:360
+#: core/handlers.py:369
 msgid "no_reminders_set"
 msgstr "You have no reminders"
 
-#: core/handlers.py:365
+#: core/handlers.py:374
 msgid "remove_set_is_day_before"
 msgstr "Remove reminder from which day?"
 
-#: core/handlers.py:439
+#: core/handlers.py:448
 msgid "reminder_is_off"
 msgstr "Reminder is turned off"
 
-#: core/handlers.py:449
+#: core/handlers.py:458
 msgid "mailing_everyone"
 msgstr "Next message will be sent to every user"
 
-#: core/handlers.py:455
+#: core/handlers.py:464
 msgid "sent_to_everyone"
 msgstr "Message is sent to everyone"
 

--- a/locales/en/LC_MESSAGES/bot.po
+++ b/locales/en/LC_MESSAGES/bot.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2020-01-16 00:41+0500\n"
+"POT-Creation-Date: 2020-02-05 14:42+0300\n"
 "PO-Revision-Date: 2019-07-22 21:06+0300\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language: en\n"
@@ -17,11 +17,11 @@ msgstr ""
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Generated-By: Babel 2.8.0\n"
- 
+
 #: core/handlers.py:94
 msgid "cancel"
 msgstr "Cancelled"
- 
+
 #: core/handlers.py:99
 msgid "start_cmd_text"
 msgstr ""
@@ -29,17 +29,7 @@ msgstr ""
 "the notification.\n"
 "Language was chosen automatically based on your client's language. Use "
 "/language to change."
- 
-#: core/handlers.py:115
-msgid "remainder_is_scheduled"
-msgstr ""
-"The next cleaning is due to"
- 
-#: core/handlers.py:118
-msgid "remainder_is_not_scheduled"
-msgstr ""
-"No cleanings scheduled. Send /on to turn on the remainder"
- 
+
 #: core/handlers.py:106
 msgid "help_cmd_text, formats: {name}"
 msgstr ""
@@ -50,67 +40,83 @@ msgstr ""
 "/start - start message\n"
 "/help - help message\n"
 "/peek - peek the next cleaning day\n"
- 
-#: core/handlers.py:114
+
+#: core/handlers.py:116
+msgid "remainder_is_scheduled"
+msgstr "The next cleaning is due to"
+
+#: core/handlers.py:120
+msgid "remainder_is_not_scheduled"
+msgstr "No cleanings scheduled. Send /on to turn on the remainder"
+
+#: core/handlers.py:130
+msgid "schedule_command_text"
+msgstr "The scheduled cleanings for each dorm respectfully:"
+
+#: core/handlers.py:143
+msgid "scheduled_cleaning"
+msgstr "#{campus_number}: {date}. In {days_left} days"
+
+#: core/handlers.py:152
 msgid "choose language"
 msgstr "Choose language"
- 
-#: core/handlers.py:132
+
+#: core/handlers.py:170
 msgid "language is set"
 msgstr "Language is set"
- 
-#: core/handlers.py:139
+
+#: core/handlers.py:177
 msgid "set_is_day_before"
 msgstr "When to remind you?"
- 
-#: core/handlers.py:159 core/handlers.py:386
+
+#: core/handlers.py:197 core/handlers.py:425
 msgid "choose_campus"
 msgstr "Choose campus"
- 
-#: core/handlers.py:186
+
+#: core/handlers.py:224
 msgid "choose_cleaning_reminder_time"
 msgstr "Choose time of reminder"
- 
-#: core/handlers.py:200
+
+#: core/handlers.py:238
 msgid "personal_reminder_cleaning_day_before"
 msgstr "Tomorrow is the day of cleaning in campus <b>{number}</b>"
- 
-#: core/handlers.py:205
+
+#: core/handlers.py:243
 msgid "personal_reminder_cleaning, formats: number"
 msgstr "Today is the day of cleaning in campus <b>{number}</b>"
- 
-#: core/handlers.py:272
+
+#: core/handlers.py:310
 msgid "cleaning_reminder_set"
 msgstr "Reminder is set"
- 
-#: core/handlers.py:332
+
+#: core/handlers.py:370
 msgid "no_reminders_set"
 msgstr "You have no reminders"
- 
-#: core/handlers.py:337
+
+#: core/handlers.py:375
 msgid "remove_set_is_day_before"
 msgstr "Remove reminder from which day?"
- 
-#: core/handlers.py:408
+
+#: core/handlers.py:449
 msgid "reminder_is_off"
 msgstr "Reminder is turned off"
- 
-#: core/handlers.py:418
+
+#: core/handlers.py:459
 msgid "mailing_everyone"
 msgstr "Next message will be sent to every user"
- 
-#: core/handlers.py:424
+
+#: core/handlers.py:465
 msgid "sent_to_everyone"
 msgstr "Message is sent to everyone"
- 
+
 #: core/reply_markups/inline.py:32
 msgid "is_day_before_inline_kb_false"
 msgstr "The day before cleaning"
- 
+
 #: core/reply_markups/inline.py:36
 msgid "is_day_before_inline_kb_true"
 msgstr "At the day of cleaning"
- 
+
 #~ msgid "personal_reminder_cleaning, formats: {number}"
 #~ msgstr "Cleaning at campus <b>{number}</b> is today"
 

--- a/locales/en/LC_MESSAGES/bot.po
+++ b/locales/en/LC_MESSAGES/bot.po
@@ -17,11 +17,11 @@ msgstr ""
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Generated-By: Babel 2.8.0\n"
-
+ 
 #: core/handlers.py:94
 msgid "cancel"
 msgstr "Cancelled"
-
+ 
 #: core/handlers.py:99
 msgid "start_cmd_text"
 msgstr ""
@@ -29,7 +29,17 @@ msgstr ""
 "the notification.\n"
 "Language was chosen automatically based on your client's language. Use "
 "/language to change."
-
+ 
+#: core/handlers.py:115
+msgid "remainder_is_scheduled"
+msgstr ""
+"The next cleaning is due to"
+ 
+#: core/handlers.py:118
+msgid "remainder_is_not_scheduled"
+msgstr ""
+"No cleanings scheduled. Send /on to turn on the remainder"
+ 
 #: core/handlers.py:106
 msgid "help_cmd_text, formats: {name}"
 msgstr ""
@@ -39,67 +49,68 @@ msgstr ""
 "/off - turn off reminder\n"
 "/start - start message\n"
 "/help - help message\n"
-
+"/peek - peek the next cleaning day\n"
+ 
 #: core/handlers.py:114
 msgid "choose language"
 msgstr "Choose language"
-
+ 
 #: core/handlers.py:132
 msgid "language is set"
 msgstr "Language is set"
-
+ 
 #: core/handlers.py:139
 msgid "set_is_day_before"
 msgstr "When to remind you?"
-
+ 
 #: core/handlers.py:159 core/handlers.py:386
 msgid "choose_campus"
 msgstr "Choose campus"
-
+ 
 #: core/handlers.py:186
 msgid "choose_cleaning_reminder_time"
 msgstr "Choose time of reminder"
-
+ 
 #: core/handlers.py:200
 msgid "personal_reminder_cleaning_day_before"
 msgstr "Tomorrow is the day of cleaning in campus <b>{number}</b>"
-
+ 
 #: core/handlers.py:205
 msgid "personal_reminder_cleaning, formats: number"
 msgstr "Today is the day of cleaning in campus <b>{number}</b>"
-
+ 
 #: core/handlers.py:272
 msgid "cleaning_reminder_set"
 msgstr "Reminder is set"
-
+ 
 #: core/handlers.py:332
 msgid "no_reminders_set"
 msgstr "You have no reminders"
-
+ 
 #: core/handlers.py:337
 msgid "remove_set_is_day_before"
 msgstr "Remove reminder from which day?"
-
+ 
 #: core/handlers.py:408
 msgid "reminder_is_off"
 msgstr "Reminder is turned off"
-
+ 
 #: core/handlers.py:418
 msgid "mailing_everyone"
 msgstr "Next message will be sent to every user"
-
+ 
 #: core/handlers.py:424
 msgid "sent_to_everyone"
 msgstr "Message is sent to everyone"
-
+ 
 #: core/reply_markups/inline.py:32
 msgid "is_day_before_inline_kb_false"
 msgstr "The day before cleaning"
-
+ 
 #: core/reply_markups/inline.py:36
 msgid "is_day_before_inline_kb_true"
 msgstr "At the day of cleaning"
-
+ 
 #~ msgid "personal_reminder_cleaning, formats: {number}"
 #~ msgstr "Cleaning at campus <b>{number}</b> is today"
 

--- a/locales/ru/LC_MESSAGES/bot.po
+++ b/locales/ru/LC_MESSAGES/bot.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2020-02-05 14:42+0300\n"
+"POT-Creation-Date: 2020-02-05 21:36+0300\n"
 "PO-Revision-Date: 2019-07-22 21:06+0300\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language: ru\n"
@@ -43,70 +43,62 @@ msgstr ""
 "/peek - посмотреть дату следующей уборки\n"
 
 #: core/handlers.py:116
-msgid "remainder_is_scheduled"
-msgstr "Следующая уборка назначена на"
-
-#: core/handlers.py:120
-msgid "remainder_is_not_scheduled"
-msgstr "Нет назначенных уборок. Чтобы включить напоминание, пришли /on"
-
-#: core/handlers.py:130
 msgid "schedule_command_text"
-msgstr "Расписание запланированных уборок для каждого корпуса соответственно:"
+msgstr "Расписание уборок для каждого корпуса соответственно:"
 
-#: core/handlers.py:143
+#: core/handlers.py:129
 msgid "scheduled_cleaning"
 msgstr "#{campus_number}: {date}. Дней осталось: {days_left}"
 
-#: core/handlers.py:152
+#: core/handlers.py:138
 msgid "choose language"
 msgstr "Выбери язык"
 
-#: core/handlers.py:170
+#: core/handlers.py:156
 msgid "language is set"
 msgstr "Язык установлен"
 
-#: core/handlers.py:177
+#: core/handlers.py:163
 msgid "set_is_day_before"
 msgstr "Когда напомнить?"
 
-#: core/handlers.py:197 core/handlers.py:425
+#: core/handlers.py:183 core/handlers.py:411
 msgid "choose_campus"
 msgstr "Выбери кампус"
 
-#: core/handlers.py:224
+#: core/handlers.py:210
 msgid "choose_cleaning_reminder_time"
 msgstr "Выбери время напоминания"
 
-#: core/handlers.py:238
+#: core/handlers.py:224
 msgid "personal_reminder_cleaning_day_before"
 msgstr "Завтра уборка в кампусе <b>{number}</b>"
 
-#: core/handlers.py:243
+#: core/handlers.py:229
 msgid "personal_reminder_cleaning, formats: number"
 msgstr "Сегодня уборка в кампусе <b>{number}</b>"
 
-#: core/handlers.py:310
+#: core/handlers.py:296
 msgid "cleaning_reminder_set"
 msgstr "Напоминание установлено"
 
-#: core/handlers.py:370
+#: core/handlers.py:356
 msgid "no_reminders_set"
 msgstr "Нет установленных напоминаний"
 
-#: core/handlers.py:375
+#: core/handlers.py:361
 msgid "remove_set_is_day_before"
 msgstr "Убрать напоминание в какой день?"
 
-#: core/handlers.py:449
+#: core/handlers.py:435
 msgid "reminder_is_off"
 msgstr "Напоминание выключено"
 
-#: core/handlers.py:459
+#: core/handlers.py:445
 msgid "mailing_everyone"
 msgstr "Следующее сообщение будет отправлено всем."
 
-#: core/handlers.py:465
+#: core/handlers.py:451
 msgid "sent_to_everyone"
 msgstr "Отправлено всем пользователям"
 

--- a/locales/ru/LC_MESSAGES/bot.po
+++ b/locales/ru/LC_MESSAGES/bot.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2020-02-05 21:36+0300\n"
+"POT-Creation-Date: 2020-02-06 11:57+0300\n"
 "PO-Revision-Date: 2019-07-22 21:06+0300\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language: ru\n"
@@ -46,59 +46,59 @@ msgstr ""
 msgid "schedule_command_text"
 msgstr "Расписание уборок для каждого корпуса соответственно:"
 
-#: core/handlers.py:129
+#: core/handlers.py:133
 msgid "scheduled_cleaning"
 msgstr "#{campus_number}: {date}. Дней осталось: {days_left}"
 
-#: core/handlers.py:138
+#: core/handlers.py:142
 msgid "choose language"
 msgstr "Выбери язык"
 
-#: core/handlers.py:156
+#: core/handlers.py:160
 msgid "language is set"
 msgstr "Язык установлен"
 
-#: core/handlers.py:163
+#: core/handlers.py:167
 msgid "set_is_day_before"
 msgstr "Когда напомнить?"
 
-#: core/handlers.py:183 core/handlers.py:411
+#: core/handlers.py:187 core/handlers.py:415
 msgid "choose_campus"
 msgstr "Выбери кампус"
 
-#: core/handlers.py:210
+#: core/handlers.py:214
 msgid "choose_cleaning_reminder_time"
 msgstr "Выбери время напоминания"
 
-#: core/handlers.py:224
+#: core/handlers.py:228
 msgid "personal_reminder_cleaning_day_before"
 msgstr "Завтра уборка в кампусе <b>{number}</b>"
 
-#: core/handlers.py:229
+#: core/handlers.py:233
 msgid "personal_reminder_cleaning, formats: number"
 msgstr "Сегодня уборка в кампусе <b>{number}</b>"
 
-#: core/handlers.py:296
+#: core/handlers.py:300
 msgid "cleaning_reminder_set"
 msgstr "Напоминание установлено"
 
-#: core/handlers.py:356
+#: core/handlers.py:360
 msgid "no_reminders_set"
 msgstr "Нет установленных напоминаний"
 
-#: core/handlers.py:361
+#: core/handlers.py:365
 msgid "remove_set_is_day_before"
 msgstr "Убрать напоминание в какой день?"
 
-#: core/handlers.py:435
+#: core/handlers.py:439
 msgid "reminder_is_off"
 msgstr "Напоминание выключено"
 
-#: core/handlers.py:445
+#: core/handlers.py:449
 msgid "mailing_everyone"
 msgstr "Следующее сообщение будет отправлено всем."
 
-#: core/handlers.py:451
+#: core/handlers.py:455
 msgid "sent_to_everyone"
 msgstr "Отправлено всем пользователям"
 

--- a/locales/ru/LC_MESSAGES/bot.po
+++ b/locales/ru/LC_MESSAGES/bot.po
@@ -18,11 +18,11 @@ msgstr ""
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Generated-By: Babel 2.8.0\n"
-
+ 
 #: core/handlers.py:94
 msgid "cancel"
 msgstr "Отменено."
-
+ 
 #: core/handlers.py:99
 msgid "start_cmd_text"
 msgstr ""
@@ -30,7 +30,17 @@ msgstr ""
 "установки напоминания.\n"
 "Язык выбран автоматически на основе языка клиента. /language позволяет "
 "поменять язык."
-
+ 
+#: core/handlers.py:115
+msgid "remainder_is_scheduled"
+msgstr ""
+"Следующая уборка назначена на"
+ 
+#: core/handlers.py:118
+msgid "remainder_is_not_scheduled"
+msgstr ""
+"Нет назначенных уборок. Чтобы включить напоминание, пришли /on"
+ 
 #: core/handlers.py:106
 msgid "help_cmd_text, formats: {name}"
 msgstr ""
@@ -40,67 +50,68 @@ msgstr ""
 "/off - выключить напоминание\n"
 "/start - приветствие\n"
 "/help - данное сообщение\n"
-
+"/peek - посмотреть дату следующей уборки\n"
+ 
 #: core/handlers.py:114
 msgid "choose language"
 msgstr "Выбери язык"
-
+ 
 #: core/handlers.py:132
 msgid "language is set"
 msgstr "Язык установлен"
-
+ 
 #: core/handlers.py:139
 msgid "set_is_day_before"
 msgstr "Когда напомнить?"
-
+ 
 #: core/handlers.py:159 core/handlers.py:386
 msgid "choose_campus"
 msgstr "Выбери кампус"
-
+ 
 #: core/handlers.py:186
 msgid "choose_cleaning_reminder_time"
 msgstr "Выбери время напоминания"
-
+ 
 #: core/handlers.py:200
 msgid "personal_reminder_cleaning_day_before"
 msgstr "Завтра уборка в кампусе <b>{number}</b>"
-
+ 
 #: core/handlers.py:205
 msgid "personal_reminder_cleaning, formats: number"
 msgstr "Сегодня уборка в кампусе <b>{number}</b>"
-
+ 
 #: core/handlers.py:272
 msgid "cleaning_reminder_set"
 msgstr "Напоминание установлено"
-
+ 
 #: core/handlers.py:332
 msgid "no_reminders_set"
 msgstr "Нет установленных напоминаний"
-
+ 
 #: core/handlers.py:337
 msgid "remove_set_is_day_before"
 msgstr "Убрать напоминание в какой день?"
-
+ 
 #: core/handlers.py:408
 msgid "reminder_is_off"
 msgstr "Напоминание выключено"
-
+ 
 #: core/handlers.py:418
 msgid "mailing_everyone"
 msgstr "Следующее сообщение будет отправлено всем."
-
+ 
 #: core/handlers.py:424
 msgid "sent_to_everyone"
 msgstr "Отправлено всем пользователям"
-
+ 
 #: core/reply_markups/inline.py:32
 msgid "is_day_before_inline_kb_false"
 msgstr "За день до уборки"
-
+ 
 #: core/reply_markups/inline.py:36
 msgid "is_day_before_inline_kb_true"
 msgstr "В день уборки"
-
+ 
 #~ msgid "personal_reminder_cleaning, formats: {number}"
 #~ msgstr "Сегодня уборка в кампусе <b>{number}</b>"
 

--- a/locales/ru/LC_MESSAGES/bot.po
+++ b/locales/ru/LC_MESSAGES/bot.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2020-02-06 11:57+0300\n"
+"POT-Creation-Date: 2020-02-06 18:41+0300\n"
 "PO-Revision-Date: 2019-07-22 21:06+0300\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language: ru\n"
@@ -40,65 +40,65 @@ msgstr ""
 "/off - выключить напоминание\n"
 "/start - приветствие\n"
 "/help - данное сообщение\n"
-"/peek - посмотреть дату следующей уборки\n"
+"/schedule - узнать расписание предстоящих уборок для каждого кампуса\n"
 
-#: core/handlers.py:116
+#: core/handlers.py:117
 msgid "schedule_command_text"
 msgstr "Расписание уборок для каждого корпуса соответственно:"
 
-#: core/handlers.py:133
+#: core/handlers.py:138
 msgid "scheduled_cleaning"
 msgstr "#{campus_number}: {date}. Дней осталось: {days_left}"
 
-#: core/handlers.py:142
+#: core/handlers.py:151
 msgid "choose language"
 msgstr "Выбери язык"
 
-#: core/handlers.py:160
+#: core/handlers.py:169
 msgid "language is set"
 msgstr "Язык установлен"
 
-#: core/handlers.py:167
+#: core/handlers.py:176
 msgid "set_is_day_before"
 msgstr "Когда напомнить?"
 
-#: core/handlers.py:187 core/handlers.py:415
+#: core/handlers.py:196 core/handlers.py:424
 msgid "choose_campus"
 msgstr "Выбери кампус"
 
-#: core/handlers.py:214
+#: core/handlers.py:223
 msgid "choose_cleaning_reminder_time"
 msgstr "Выбери время напоминания"
 
-#: core/handlers.py:228
+#: core/handlers.py:237
 msgid "personal_reminder_cleaning_day_before"
 msgstr "Завтра уборка в кампусе <b>{number}</b>"
 
-#: core/handlers.py:233
+#: core/handlers.py:242
 msgid "personal_reminder_cleaning, formats: number"
 msgstr "Сегодня уборка в кампусе <b>{number}</b>"
 
-#: core/handlers.py:300
+#: core/handlers.py:309
 msgid "cleaning_reminder_set"
 msgstr "Напоминание установлено"
 
-#: core/handlers.py:360
+#: core/handlers.py:369
 msgid "no_reminders_set"
 msgstr "Нет установленных напоминаний"
 
-#: core/handlers.py:365
+#: core/handlers.py:374
 msgid "remove_set_is_day_before"
 msgstr "Убрать напоминание в какой день?"
 
-#: core/handlers.py:439
+#: core/handlers.py:448
 msgid "reminder_is_off"
 msgstr "Напоминание выключено"
 
-#: core/handlers.py:449
+#: core/handlers.py:458
 msgid "mailing_everyone"
 msgstr "Следующее сообщение будет отправлено всем."
 
-#: core/handlers.py:455
+#: core/handlers.py:464
 msgid "sent_to_everyone"
 msgstr "Отправлено всем пользователям"
 

--- a/locales/ru/LC_MESSAGES/bot.po
+++ b/locales/ru/LC_MESSAGES/bot.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2020-01-16 00:41+0500\n"
+"POT-Creation-Date: 2020-02-05 14:42+0300\n"
 "PO-Revision-Date: 2019-07-22 21:06+0300\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language: ru\n"
@@ -18,11 +18,11 @@ msgstr ""
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Generated-By: Babel 2.8.0\n"
- 
+
 #: core/handlers.py:94
 msgid "cancel"
 msgstr "Отменено."
- 
+
 #: core/handlers.py:99
 msgid "start_cmd_text"
 msgstr ""
@@ -30,17 +30,7 @@ msgstr ""
 "установки напоминания.\n"
 "Язык выбран автоматически на основе языка клиента. /language позволяет "
 "поменять язык."
- 
-#: core/handlers.py:115
-msgid "remainder_is_scheduled"
-msgstr ""
-"Следующая уборка назначена на"
- 
-#: core/handlers.py:118
-msgid "remainder_is_not_scheduled"
-msgstr ""
-"Нет назначенных уборок. Чтобы включить напоминание, пришли /on"
- 
+
 #: core/handlers.py:106
 msgid "help_cmd_text, formats: {name}"
 msgstr ""
@@ -51,67 +41,83 @@ msgstr ""
 "/start - приветствие\n"
 "/help - данное сообщение\n"
 "/peek - посмотреть дату следующей уборки\n"
- 
-#: core/handlers.py:114
+
+#: core/handlers.py:116
+msgid "remainder_is_scheduled"
+msgstr "Следующая уборка назначена на"
+
+#: core/handlers.py:120
+msgid "remainder_is_not_scheduled"
+msgstr "Нет назначенных уборок. Чтобы включить напоминание, пришли /on"
+
+#: core/handlers.py:130
+msgid "schedule_command_text"
+msgstr "Расписание запланированных уборок для каждого корпуса соответственно:"
+
+#: core/handlers.py:143
+msgid "scheduled_cleaning"
+msgstr "#{campus_number}: {date}. Дней осталось: {days_left}"
+
+#: core/handlers.py:152
 msgid "choose language"
 msgstr "Выбери язык"
- 
-#: core/handlers.py:132
+
+#: core/handlers.py:170
 msgid "language is set"
 msgstr "Язык установлен"
- 
-#: core/handlers.py:139
+
+#: core/handlers.py:177
 msgid "set_is_day_before"
 msgstr "Когда напомнить?"
- 
-#: core/handlers.py:159 core/handlers.py:386
+
+#: core/handlers.py:197 core/handlers.py:425
 msgid "choose_campus"
 msgstr "Выбери кампус"
- 
-#: core/handlers.py:186
+
+#: core/handlers.py:224
 msgid "choose_cleaning_reminder_time"
 msgstr "Выбери время напоминания"
- 
-#: core/handlers.py:200
+
+#: core/handlers.py:238
 msgid "personal_reminder_cleaning_day_before"
 msgstr "Завтра уборка в кампусе <b>{number}</b>"
- 
-#: core/handlers.py:205
+
+#: core/handlers.py:243
 msgid "personal_reminder_cleaning, formats: number"
 msgstr "Сегодня уборка в кампусе <b>{number}</b>"
- 
-#: core/handlers.py:272
+
+#: core/handlers.py:310
 msgid "cleaning_reminder_set"
 msgstr "Напоминание установлено"
- 
-#: core/handlers.py:332
+
+#: core/handlers.py:370
 msgid "no_reminders_set"
 msgstr "Нет установленных напоминаний"
- 
-#: core/handlers.py:337
+
+#: core/handlers.py:375
 msgid "remove_set_is_day_before"
 msgstr "Убрать напоминание в какой день?"
- 
-#: core/handlers.py:408
+
+#: core/handlers.py:449
 msgid "reminder_is_off"
 msgstr "Напоминание выключено"
- 
-#: core/handlers.py:418
+
+#: core/handlers.py:459
 msgid "mailing_everyone"
 msgstr "Следующее сообщение будет отправлено всем."
- 
-#: core/handlers.py:424
+
+#: core/handlers.py:465
 msgid "sent_to_everyone"
 msgstr "Отправлено всем пользователям"
- 
+
 #: core/reply_markups/inline.py:32
 msgid "is_day_before_inline_kb_false"
 msgstr "За день до уборки"
- 
+
 #: core/reply_markups/inline.py:36
 msgid "is_day_before_inline_kb_true"
 msgstr "В день уборки"
- 
+
 #~ msgid "personal_reminder_cleaning, formats: {number}"
 #~ msgstr "Сегодня уборка в кампусе <b>{number}</b>"
 


### PR DESCRIPTION
This feature will allow users to peek the next day of cleaning.  I called it `/peek`, but we can change the name if it will appear not to be clear.

Please notice that I did not change the corresponding row numbers in the `.po` files. I am still wondering if it makes any sense to specify the rows and do it manually any time the code is changed.